### PR TITLE
Issue #17 setup file

### DIFF
--- a/scripts/build_catkin_workspace.sh
+++ b/scripts/build_catkin_workspace.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-# Setup
-source /opt/ros/groovy/setup.bash
 
 # variables
 SETUP_FILE=$WORKSPACE"/setup.bash"

--- a/scripts/clean_catkin_workspace.sh
+++ b/scripts/clean_catkin_workspace.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# merge new entries in workspace (.rosinstall) file and update all tracked repos
+
+# variables
+SETUP_FILE=$WORKSPACE"/setup.bash"
+CMAKELISTS_FILE=$WORKSPACE"/src/CMakeLists.txt"
+DEVEL_DIR=$WORKSPACE"/devel"
+INSTALL_DIR=$WORKSPACE"/install"
+
+# placing all items into array
+items="$CMAKELISTS_FILE $DEVEL_DIR $INSTALL_DIR"
+
+# removing files and directories
+for item in $items;
+do
+
+	echo "- checking $item"
+	if [ -f $item ];
+	then
+		rm -R $item
+		echo "- removed $item"
+	fi
+
+	if [ -d $item ];
+	then
+		rm -R $item
+		echo "- removed $item"
+	fi
+
+	echo "- done with $item"
+
+done
+
+
+# creating new cmakelist file
+source $SETUP_FILE
+cd $WORKSPACE"/src"
+capture_stdout=$(catkin_init_workspace)
+
+
+
+

--- a/scripts/create_catkin_workspace.sh
+++ b/scripts/create_catkin_workspace.sh
@@ -1,31 +1,31 @@
 #!/bin/bash
-# Setup
-source /opt/ros/groovy/setup.bash >&1
 
 # variables
 WORKSPACE=$1
 JOB_WORKSPACE_FILE=$2
 
-#echo "============ Initializing and building catking workspace =============" >&1
-
 # initializing ros workspace 
-mkdir -p "$WORKSPACE/src" # creating source directory for catkin workspace
+mkdir -p "$WORKSPACE" 
 cd $WORKSPACE # entering job workspace
 capture_stdout=$(rosws init ${WORKSPACE})
+capture_stdout=$(rosws merge ${JOB_WORKSPACE_FILE} -y)
+source "$WORKSPACE/setup.bash" # sources ros distro setup.bash 
 
-#initializing catking workspace
+# initializing catkin workspace
+mkdir -p "$WORKSPACE/src" 
 cd "$WORKSPACE/src"
 capture_stdout=$(catkin_init_workspace)
 
 #building catkin workspace 
-cd $WORKSPACE
-capture_stdout=$(catkin_make)
+#cd $WORKSPACE
+#capture_stdout=$(catkin_make)
 
 # merging workspaces
-capture_stdout=$(cat $WORKSPACE/devel/.rosinstall | rosws merge - )
-capture_stdout=$(rosws merge ${JOB_WORKSPACE_FILE} -y )
+#capture_stdout=$(cat $WORKSPACE/devel/.rosinstall | rosws merge - )
 
 # cloning all git repositories in src directory
+cd $WORKSPACE
 capture_stdout=$(rosws update -v )
+
 
 

--- a/scripts/run_build_scripts.sh
+++ b/scripts/run_build_scripts.sh
@@ -18,7 +18,10 @@ $JOB_SCRIPTS_PATH"/run_codecount.bash" $WORKSPACE"/src"
 $JOB_SCRIPTS_PATH"/run_cppcheck.bash" $WORKSPACE"/src"
 
 # Coverage
-#source $WORKSPACE"/../scripts/run_gcorv.bash" $WORKSPACE"/src"
+source $WORKSPACE"/../scripts/run_gcorv.bash" $WORKSPACE"/src"
+
+# build catkin ws
+$JOB_SCRIPTS_PATH"/clean_catkin_workspace.sh"
 
 # build catkin ws
 $JOB_SCRIPTS_PATH"/build_catkin_workspace.sh"

--- a/scripts/trigger_jobs.sh
+++ b/scripts/trigger_jobs.sh
@@ -9,6 +9,7 @@ export JENKINS_CMD="java -jar "${JENKINS_CLI}" -s http://localhost:8080"
 
 echo "updating jenkins_config repository"
 cd ${JENKINS_HOME}/jenkins_config && git pull #&>/dev/null
+chmod a+rwx -R ${SCRIPTS_PATH}
 
 if [ ! -f $JENKINS_CLI ];
 then

--- a/scripts/update_catkin_workspace.sh
+++ b/scripts/update_catkin_workspace.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
-# merge .rosinstall file and the calls rosws to update all repos
-
-# Setup
-source /opt/ros/groovy/setup.bash
+# merge new entries in workspace (.rosinstall) file and update all tracked repos
 
 # variables
 SETUP_FILE=$WORKSPACE"/setup.bash"
@@ -11,6 +8,9 @@ ROS_INSTALL_FILE=${JENKINS_HOME}/jenkins_config/workspaces/${JOB_NAME}.rosinstal
 # merging workspace file
 if [ -f $ROS_INSTALL_FILE ];
 then
+	# reset ros workspace file
+	echo "" > "$WORKSPACE/.rosinstall"
+
 	echo "updating workspace file $ROS_INSTALL_FILE"
 	cd ${WORKSPACE}
 	rosws merge ${ROS_INSTALL_FILE} -r -y

--- a/workspaces/jenkins_test.rosinstall
+++ b/workspaces/jenkins_test.rosinstall
@@ -4,3 +4,5 @@
 - git: {local-name: src/motoman, version: groovy-devel, uri: 'https://github.com/ros-industrial/motoman.git'}
 - git: {local-name: src/universal_robot, version: groovy-devel, uri: 'https://github.com/ros-industrial/universal_robot.git'}
 - git: {local-name: src/industrial_experimental, version: groovy-devel, uri: 'https://github.com/ros-industrial/industrial_experimental.git'}
+- setup-file:
+    local-name: /opt/ros/groovy/setup.bash

--- a/workspaces/ros_industrial_groovy_dev.rosinstall
+++ b/workspaces/ros_industrial_groovy_dev.rosinstall
@@ -4,3 +4,5 @@
 - git: {local-name: src/motoman, version: groovy-devel, uri: 'https://github.com/ros-industrial/motoman.git'}
 - git: {local-name: src/universal_robot, version: groovy-devel, uri: 'https://github.com/ros-industrial/universal_robot.git'}
 - git: {local-name: src/industrial_experimental, version: groovy-devel, uri: 'https://github.com/ros-industrial/industrial_experimental.git'}
+- setup-file:
+    local-name: /opt/ros/groovy/setup.bash

--- a/workspaces/ros_industrial_hydro_dev.rosinstall
+++ b/workspaces/ros_industrial_hydro_dev.rosinstall
@@ -4,3 +4,5 @@
 #- git: {local-name: src/motoman, version: groovy-devel, uri: 'https://github.com/ros-industrial/motoman.git'}
 #- git: {local-name: src/universal_robot, version: groovy-devel, uri: 'https://github.com/ros-industrial/universal_robot.git'}
 #- git: {local-name: src/industrial_experimental, version: groovy-devel, uri: 'https://github.com/ros-industrial/industrial_experimental.git'}
+- setup-file:
+    local-name: /opt/ros/hydro/setup.bash


### PR DESCRIPTION
The latest changes make it possible to create and build jenkins jobs for different versions of the ros system.  However, the following guidelines must be kept in mind:

Before merge:
- Install new ros version and other especial features (moveit, etc ..) in the server that runs the jenkins system.

After merge
- Do not mix repos for different ros system versions in the same workspace file
- From now on, all workspace files must contain a " setup-flle" item which points to the setup.bash script for the version of ros corresponding to the repos listed elsewhere in this file
